### PR TITLE
`class_copyMethodList` memory leak fix

### DIFF
--- a/EasyKVO/EasyKVO/EasyKVO/NSObject+KVOBlock.m
+++ b/EasyKVO/EasyKVO/EasyKVO/NSObject+KVOBlock.m
@@ -103,15 +103,18 @@ static void lxz_kvoSetter(id self, SEL selector, id value) {
 - (BOOL)lxz_hasMethodWithKey:(SEL)key {
     NSString *setterName = NSStringFromSelector(key);
     unsigned int count;
+    BOOL ret = NO;
     Method *methodList = class_copyMethodList(object_getClass(self), &count);
     for (NSInteger i = 0; i < count; i++) {
         Method method = methodList[i];
         NSString *methodName = NSStringFromSelector(method_getName(method));
         if ([methodName isEqualToString:setterName]) {
-            return YES;
+            ret = YES;
+            break;
         }
     }
-    return NO;
+    free(methodList);
+    return ret;
 }
 
 static NSString * lxz_getterForSetter(SEL setter) {

--- a/EasyKVO/EasyKVO/KVOObject.m
+++ b/EasyKVO/EasyKVO/KVOObject.m
@@ -32,6 +32,7 @@
         NSString *methodName = NSStringFromSelector(method_getName(method));
         NSLog(@"method Name = %@\n", methodName);
     }
+    free(methodList);
     
     return @"";
 }


### PR DESCRIPTION
Method list copied by `class_copyMethodList` should be freed to avoid memory leak.